### PR TITLE
Support extended SemVer where applicable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 node_modules
 package-lock.json
 lib/
+android
+ios

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .idea
+.vscode
 node_modules
 package-lock.json
+lib/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@andrioid/react-native-version-setter",
-	"version": "2.0.0",
+	"version": "2.0.4",
 	"description": "Fork. Update your app version with a single command.",
 	"homepage": "https://www.github.com/tj-mc/react-native-version-setter",
 	"main": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-	"name": "react-native-version-setter",
-	"version": "1.0.7",
-	"description": "Update your app version with a single command.",
+	"name": "@andrioid/react-native-version-setter",
+	"version": "2.0.0",
+	"description": "Fork. Update your app version with a single command.",
 	"homepage": "https://www.github.com/tj-mc/react-native-version-setter",
 	"main": "lib/index.js",
 	"scripts": {

--- a/src/createLocations.js
+++ b/src/createLocations.js
@@ -5,20 +5,20 @@ export const createLocations = (version, packageJson, platform = null) => {
     const allLocations = [
         {
             files: './android/app/build.gradle',
-            from: new RegExp('versionCode [0-9]+', 'g'),
-            to: `versionCode ${version.stripped}`,
-            platform: constants.platform.android
-        },
-        {
-            files: './android/app/build.gradle',
-            from: new RegExp('^versionName ([0-9, .])+([-+][a-z0-9]+)?$'),
-            to: `versionName ${version.raw}`,
+            from: [
+                new RegExp('versionCode [0-9]+', 'g'),
+                new RegExp('versionName "([0-9, .])+([-+][a-z0-9]+)?"')
+            ],
+            to: [
+                `versionCode ${version.stripped}`,
+                `versionName "${version.raw}"`
+            ],
             platform: constants.platform.android
         },
         {
             files: `./ios/${packageJson.name}.xcodeproj/project.pbxproj`,
             from: new RegExp('MARKETING_VERSION = [0-9, .]+', 'g'),
-            to: `MARKETING_VERSION = ${version.raw}`,
+            to: `MARKETING_VERSION = ${version.core}`,
             platform: constants.platform.ios
         },
         {

--- a/src/createLocations.js
+++ b/src/createLocations.js
@@ -11,8 +11,8 @@ export const createLocations = (version, packageJson, platform = null) => {
         },
         {
             files: './android/app/build.gradle',
-            from: new RegExp('versionName "[0-9, .]+"', 'g'),
-            to: `versionName "${version.raw}"`,
+            from: new RegExp('^versionName ([0-9, .])+([-+][a-z0-9]+)?$'),
+            to: `versionName ${version.raw}`,
             platform: constants.platform.android
         },
         {

--- a/src/process.js
+++ b/src/process.js
@@ -8,5 +8,5 @@ export const die = message => {
 }
 
 export const cliArgumentExists = flag => {
-    process.argv.find(arg => arg === flag)
+    return !!process.argv.find(arg => arg === flag)
 }

--- a/src/setVersion.js
+++ b/src/setVersion.js
@@ -16,6 +16,10 @@ const commandLineFlags = {
     debugLog: {
         argument: '-d',
         set: false
+    },
+    dryRun: {
+        argument: '-r',
+        set: false
     }
 }
 
@@ -28,23 +32,38 @@ Object.keys(commandLineFlags).forEach(key => {
     commandLineFlags[key].set = cliArgumentExists(commandLineFlags[key].argument)
 })
 
+
+
 /**
  * Check for valid version strings.
  */
 const version = {
-    validRegEx: /^[0-9, .]+[0-9]+$/,  // Test to validate version strings
-                                      // Cannot end or start with .
-                                      // Must be only digit and .
-
+    validRegEx: /^([0-9, .]+)([-+][a-z0-9]+)?$/,
+                                      // Semantic Versioning 2.0
     raw: process.argv[2]              // The raw input version string
+}
+
+/**
+ * Replacer function to strip beta/rc from ios versions
+ */
+
+function replacer(match, p1, p2, offset, string) {
+    // just strips away the second match
+    return p1
 }
 
 /**
  * Error messages
  */
 version.raw || die(`Please provide a version number. ${emoji.warning}`)
-version.validRegEx.test(version.raw) || die(`Your version number should contain only digits and periods. ${emoji.warning} `)
-version.stripped = version.raw.split('.').join('')
+version.validRegEx.test(version.raw) || die(`Usage: setVersion <version> [args] ${emoji.warning} `)
+version.core = version.raw.replace(version.validRegEx, replacer)
+version.stripped = version.core.split('.').join('')
+
+if (commandLineFlags.dryRun.set) {
+    console.log(version);
+    die()
+}
 
 const locations = createLocations(version, packageJson)
 


### PR DESCRIPTION
### Changes

- Fixed the `-d` CLI argument. It wasn't working
- Added `-r` for a dry-run. Just prints the parsed versions
- Fixed the `app/build.gradle` replacements so that it doesn't ignore versionName any more and simply does both replacements in one go. Before, the replace-in-files was returning "not changed" for the second match.
- **Now allows versions like `1.0.1-beta2` or `1.03+20201002`**. IOS still receives the plain vanilla 1.0.1 here; so if your version scheme abides with iOS standards; there should be no breaking changes.

*NOTE: `package.json` file needs work before you can merge this, if you want to*

### Background

I find my self doing a bunch of point-releases on Android these days and I was frustrated that https://github.com/tj-mc/react-native-version-setter/issues/4 was impossible, due to iOS.

I needed this for work, and if you want to use it. That is fine. But, if you feel that I'm taking the project in a wrong direction; that's fine too.