### PR TITLE
Add support for config files

### DIFF
--- a/src/createLocations.js
+++ b/src/createLocations.js
@@ -5,9 +5,12 @@ import {constants} from './constants.js'
  * @param version
  * @param packageJson
  * @param platform
+ * @param config
  * @returns Array
  */
-export const createLocations = (version, packageJson, platform = null) => {
+export const createLocations = (version, packageJson, platform = null, config) => {
+
+    const iosProjectName = config.iosProjectName || packageJson.name
 
     const allLocations = [
         {
@@ -23,7 +26,7 @@ export const createLocations = (version, packageJson, platform = null) => {
             platform: constants.platform.android
         },
         {
-            files: `./ios/${packageJson.name}.xcodeproj/project.pbxproj`,
+            files: `./ios/${iosProjectName}.xcodeproj/project.pbxproj`,
             from: new RegExp('MARKETING_VERSION = [0-9, .]+', 'g'),
             to: `MARKETING_VERSION = ${version.core}`,
             platform: constants.platform.ios

--- a/src/readConfig.js
+++ b/src/readConfig.js
@@ -1,0 +1,22 @@
+import {die, out} from "./process";
+
+const fs = require('fs')
+
+export const readConfig = commandLineFlags => {
+
+    let config
+    try {
+        config = String(fs.readFileSync('.rnvs.json'))
+    } catch (e) {
+        return {}
+    }
+
+    try {
+        config = JSON.parse(config)
+        commandLineFlags.debugLog.set && out("Using config file.")
+        return config
+    } catch (e) {
+        die('Error reading .rnvs.json file.')
+    }
+
+}

--- a/src/setVersion.js
+++ b/src/setVersion.js
@@ -6,12 +6,16 @@ import {getPlatformConstant} from "./getPlatformConstant";
 import {createVersion} from "./createVersion";
 import {mutateFiles} from "./mutateFiles";
 import {createCliFlags} from "./createCliFlags";
+import {readConfig} from "./readConfig";
 
 // Read package.json
 const packageJson = readPackageJson() || die('Could not read package.json.')
 
 // Create and check for all CLI flags
 const commandLineFlags = createCliFlags()
+
+// Read config file
+const config = readConfig(commandLineFlags)
 
 // Create the version object
 const version = createVersion(process.argv[2])
@@ -20,7 +24,7 @@ const version = createVersion(process.argv[2])
 const platform = getPlatformConstant(commandLineFlags)
 
 // Get locations for specified version, or all if no version is specified
-const locations = createLocations(version, packageJson, platform)
+const locations = createLocations(version, packageJson, platform, config)
 
 // If dryRun is set, just print versions
 commandLineFlags.dryRun.set && logDie(version, 'No changes applied.')


### PR DESCRIPTION
You can configure RNVS with a `.rnvs.json` file. For now, the only option is `iosProjectName`. Resolves #3 