### PR TITLE
Update createCliFlags.js

### DIFF
--- a/src/createCliFlags.js
+++ b/src/createCliFlags.js
@@ -1,4 +1,4 @@
-import {cliArgumentExists} from "../lib/process";
+import {cliArgumentExists} from ".process";
 
 const flags = [
     {


### PR DESCRIPTION
Fix import reference to process.js file

This addresses an exception I was receiving, when running setVersion:
```
internal/modules/cjs/loader.js:883
  throw err;
  ^

Error: Cannot find module '../lib/process'
```